### PR TITLE
reduce retention of binaries artifacts, fix workflow using secret

### DIFF
--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -75,9 +75,10 @@ jobs:
       - name: Get Binaries
         id: binaries-matrix
         run: |
+          binaries="$(find . -name 'zephyr.bin')"
           binaries_matrix="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
           boards=""
-          for binary in ${binaries_matrix}; do
+          for binary in ${binaries}; do
             boards="${boards} $(echo ${binary} | cut -d '/' -f 2)"
           done
           artifacts_names=""

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -76,8 +76,15 @@ jobs:
 
       - name: Get MCUboot binaries
         uses: actions/download-artifact@v3
+        id: download
         with:
           name: ${{ needs.mcuboot_compil.outputs.binaries }}
+
+      - name: ':toolbox: Show artifacts'
+        run: |
+          find ${{ steps.download.outputs.download-path }}
+          echo "---------"
+          echo "This job process ${{ matrix.mcuboot }}"
 
       - name: Get Board Name
         id: board-name

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: ':toolbox: Show artifacts'
         run: |
-          find ${{ steps.download.outputs.download-path }}
+          find .
           echo "---------"
           echo "This job process ${{ matrix.mcuboot }}"
 

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -125,7 +125,8 @@ jobs:
       - name: Upload MCUboot Binaries
         uses: actions/upload-artifact@v3
         with:
-          retention-days: 7
+          # We don't care of the binaries after the run
+          retention-days: 1
           name: ${{ steps.artifact-name.outputs.artifact_name }}
           path: |
             ${{ steps.mcuboot-stm32h7-banks.outputs.mcuboot-bank1-hexfile }}

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           name: ${{ needs.mcuboot_compil.outputs.binaries }}
 
-      - name: ':toolbox: Show artifacts'
+      - name: 'Show artifacts'
         run: |
           find .
           echo "---------"
@@ -115,7 +115,7 @@ jobs:
         id: matrix-artifacts-names
         run: |
           artifacts=""
-          for binary in $(echo ${{ needs.mcuboot_compil.outputs.binary-list }} | jq -r '.[]'); do
+          for binary in $(echo '${{ needs.mcuboot_compil.outputs.binary-list }}' | jq -r '.[]'); do
             board="$(echo ${binary} | cut -d '/' -f 2)"
             artifact_name="${board}${ARTIFACT_SUFFIX}"
             artifacts="${artifacts} ${artifact_name}"

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -33,7 +33,7 @@ on:
     outputs:
       mcuboot-progfiles:
         description: 'Artifact name containing mcuboot programming files for each bank.'
-        value: ${{ jobs.sreccat.outputs.artifact-name }}
+        value: ${{ jobs.matrix_input.outputs.artifacts-names }}
 
       binaries:
         description: 'Artifact name containing binaires, retrieved from compilation job.'
@@ -42,7 +42,6 @@ on:
       logs:
         description: 'Artifact name containing the build logs, retrieved from compilation job.'
         value: ${{ jobs.mcuboot_compil.outputs.logs }}
-
 
 
 jobs:
@@ -58,18 +57,16 @@ jobs:
     secrets:
       signing-key: ${{ secrets.signing-key }}
 
-  get_mcuboot_bins:
+  matrix_input:
     needs: mcuboot_compil
     name: MCUboot Binary Matrix
     runs-on: ubuntu-latest
     outputs:
       binaries-matrix: ${{ steps.binaries-matrix.outputs.binaries_matrix }}
+      artifacts-names: ${{ steps.binaries-matrix.outputs.artifacts_names }}
+      boards: ${{ steps.binaries-matrix.outputs.boards }}
 
     steps:
-      - name: dbg artifcat name
-        run: |
-          echo "${{ needs.mcuboot_compil.outputs.binaries }}"
-
       - name: Get MCUboot binaries
         uses: actions/download-artifact@v3
         with:
@@ -79,8 +76,17 @@ jobs:
         id: binaries-matrix
         run: |
           binaries_matrix="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
-          echo "binaries_matrix=${binaries_matrix}" >> $GITHUB_OUTPUT
-          echo "binaries_matrix=${binaries_matrix}"
+          boards=""
+          for binary in ${binaries_matrix}; do
+            boards="${boards} $(echo ${binary} | cut -d '/' -f 2)"
+          done
+          artifacts_names=""
+          for board in ${boards}; do
+            artifacts_names="${artifacts_names} ${board}-mcuboot-progfiles"
+          done
+          echo "binaries_matrix=${binaries_matrix}" | tee -a $GITHUB_OUTPUT
+          echo "boards=${boards}" | tee -a $GITHUB_OUTPUT
+          echo "artifacts_names=${artifacts_names}" | tee -a $GITHUB_OUTPUT
 
 
   sreccat:
@@ -88,12 +94,10 @@ jobs:
     name: MCUboot files for stm32h7 banks
     needs:
       - mcuboot_compil
-      - get_mcuboot_bins
+      - matrix_input
     strategy:
       matrix:
-        mcuboot: ${{ fromJson(needs.get_mcuboot_bins.outputs.binaries-matrix) }}
-    outputs:
-      artifact-name: ${{ steps.artifact-name.outputs.artifact_name }}
+        mcuboot: ${{ fromJson(needs.matrix_input.outputs.binaries-matrix) }}
 
     steps:
       - name: install srec_cat

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -33,7 +33,7 @@ on:
     outputs:
       mcuboot-progfiles:
         description: 'Artifact name containing mcuboot programming files for each bank.'
-        value: ${{ jobs.matrix_input.outputs.artifacts-names }}
+        value: ${{ jobs.sreccat.outputs.artifacts-names }}
 
       binaries:
         description: 'Artifact name containing binaires, retrieved from compilation job.'
@@ -57,48 +57,18 @@ jobs:
     secrets:
       signing-key: ${{ secrets.signing-key }}
 
-  matrix_input:
-    needs: mcuboot_compil
-    name: MCUboot Binary Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      binaries-matrix: ${{ steps.binaries-matrix.outputs.binaries_matrix }}
-      artifacts-names: ${{ steps.binaries-matrix.outputs.artifacts_names }}
-      boards: ${{ steps.binaries-matrix.outputs.boards }}
-
-    steps:
-      - name: Get MCUboot binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.mcuboot_compil.outputs.binaries }}
-
-      - name: Get Binaries
-        id: binaries-matrix
-        run: |
-          binaries="$(find . -name 'zephyr.bin')"
-          binaries_matrix="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
-          boards=""
-          for binary in ${binaries}; do
-            boards="${boards} $(echo ${binary} | cut -d '/' -f 2)"
-          done
-          artifacts_names=""
-          for board in ${boards}; do
-            artifacts_names="${artifacts_names} ${board}-mcuboot-progfiles"
-          done
-          echo "binaries_matrix=${binaries_matrix}" | tee -a $GITHUB_OUTPUT
-          echo "boards=${boards}" | tee -a $GITHUB_OUTPUT
-          echo "artifacts_names=${artifacts_names}" | tee -a $GITHUB_OUTPUT
-
-
   sreccat:
     runs-on: ubuntu-latest
     name: MCUboot files for stm32h7 banks
     needs:
       - mcuboot_compil
-      - matrix_input
     strategy:
       matrix:
-        mcuboot: ${{ fromJson(needs.matrix_input.outputs.binaries-matrix) }}
+        mcuboot: ${{ fromJson(needs.mcuboot_compil.outputs.binary-list) }}
+    env:
+      ARTIFACT_SUFFIX: '-mcuboot-progfiles'
+    outputs:
+      artifacts-names: ${{ steps.matrix-artifacts-names.outputs.artifacts }}
 
     steps:
       - name: install srec_cat
@@ -125,9 +95,25 @@ jobs:
       - name: Artifact name
         id: artifact-name
         run: |
-          artifact_name=${{ steps.board-name.outputs.board }}-mcuboot-progfiles
+          artifact_name=${{ steps.board-name.outputs.board }}${ARTIFACT_SUFFIX}
           echo "artifact_name=${artifact_name}"
           echo "artifact_name=${artifact_name}" >> $GITHUB_OUTPUT
+
+      # It is not yet possible to get each output of matrix jobs
+      # https://github.com/actions/runner/pull/2477
+      # Although the PR is merged in, some server side dev is required and the team responsible for this have been fired
+      # https://github.com/actions/runner/pull/2477#issuecomment-1501003600
+      # This steps compute artifacts names across the job matrix.
+      - name: Artifacts Names across Matrix
+        id: matrix-artifacts-names
+        run: |
+          artifacts=""
+          for binary in $(echo ${{ needs.mcuboot_compil.outputs.binary-list }} | jq -r '.[]'); do
+            board="$(echo ${binary} | cut -d '/' -f 2)"
+            artifact_name="${board}${ARTIFACT_SUFFIX}"
+            artifacts="${artifacts} ${artifact_name}"
+          done
+          echo "artifacts=${artifacts}" | tee -a $GITHUB_OUTPUT
 
       - name: Upload MCUboot Binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   mcuboot_compil:
-    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v1
+    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@fix_matrix_output
     with:
       app-dir: bootloader/mcuboot/boot/zephyr/
       board-root-dir: ${{ inputs.board-root-dir }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: MCUboot STM32 H7 banks
         id: mcuboot-stm32h7-banks
-        uses: SiemaApplications/vossloh-gh-actions/mcuboot/stm32h7-banks@v1
+        uses: SiemaApplications/vossloh-gh-actions/mcuboot/stm32h7-banks@fix_matrix_output
         with:
           mcuboot-binfile: ${{ matrix.mcuboot }}
           board-name: ${{ steps.board-name.outputs.board }}

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -41,7 +41,7 @@ on:
         description: 'Artifact name containing the binaries'
         value: ${{ jobs.compile.outputs.binaries }}
 
-      binary_list:
+      binary-list:
         description: 'Json list of binary files produced by this job.'
         value: ${{ jobs.compile.outputs.binary-list }}
 

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Compute Job Outputs
         id: jobs-outputs
         run: |
+          cd ${{ inputs.twister-outdir }}
           binaries="${{ inputs.twister-outdir }}-binaries"
           logs="${{ inputs.twister-outdir }}-build-logs"
           binary_list="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -194,7 +194,8 @@ jobs:
       - name: Upload Binaries
         uses: actions/upload-artifact@v3
         with:
-          retention-days: 7
+          # We don't care of the binaries after the run
+          retention-days: 1
           name: ${{ steps.jobs-outputs.outputs.binaries }}
           path: |
             ${{ inputs.twister-outdir }}/**/*.bin

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -129,9 +129,6 @@ jobs:
           ls -l ${{ inputs.key-file }}
           echo "md5 of ${{ inputs.key-file }}"
           md5sum ${{ inputs.key-file }}
-          echo "md5 of secret"
-          echo ${{ secrets.signing-key }} | md5sum
-          echo ${{ secrets.signing-key }} | wc -l
           keyfile_sz=$(ls -l ${{ inputs.key-file }} | awk '{print $5}')
           echo "keyfile_sz=${keyfile_sz}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -74,16 +74,6 @@ jobs:
           echo "repo_name=${repo_name}" >> $GITHUB_OUTPUT
           echo "manifest=${repo_name}/west.yml" >> $GITHUB_OUTPUT
 
-      - name: Compute Job Outputs
-        id: jobs-outputs
-        run: |
-          binaries="${{ inputs.twister-outdir }}-binaries"
-          logs="${{ inputs.twister-outdir }}-build-logs"
-          binary_list="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
-          echo "binaries=${binaries}" | tee -a $GITHUB_OUTPUT
-          echo "binary_list=${binary_list}" | tee -a $GITHUB_OUTPUT
-          echo "logs=${logs}" | tee -a $GITHUB_OUTPUT
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -180,6 +170,16 @@ jobs:
             ${{ steps.twister-args.outputs.outdir }} \
             ${{ steps.twister-args.outputs.testsuite_root }} \
             ${{ steps.twister-args.outputs.testargs }}
+
+      - name: Compute Job Outputs
+        id: jobs-outputs
+        run: |
+          binaries="${{ inputs.twister-outdir }}-binaries"
+          logs="${{ inputs.twister-outdir }}-build-logs"
+          binary_list="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+          echo "binaries=${binaries}" | tee -a $GITHUB_OUTPUT
+          echo "binary_list=${binary_list}" | tee -a $GITHUB_OUTPUT
+          echo "logs=${logs}" | tee -a $GITHUB_OUTPUT
 
       - name: Upload Build Logs
         if: always()

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -201,6 +201,6 @@ jobs:
             !${{ inputs.twister-outdir }}/**/isrList.bin
 
       - name: Check Twister Results
-        uses: SiemaApplications/vossloh-gh-actions/twister/results-analysis@v1
+        uses: SiemaApplications/vossloh-gh-actions/twister/results-analysis@fix_matrix_output
         with:
           twister-result-file: ${{ inputs.twister-outdir }}/twister.json

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -41,6 +41,10 @@ on:
         description: 'Artifact name containing the binaries'
         value: ${{ jobs.compile.outputs.binaries }}
 
+      binary_list:
+        description: 'Json list of binary files produced by this job.'
+        value: ${{ jobs.compile.outputs.binary-list }}
+
       logs:
         description: 'Artifact name containing the build logs'
         value: ${{ jobs.compile.outputs.logs }}
@@ -50,8 +54,9 @@ jobs:
     name: Twister Signed Compilation
     runs-on: ubuntu-latest
     outputs:
-      binaries: ${{ steps.artifacts-names.outputs.binaries }}
-      logs: ${{ steps.artifacts-names.outputs.logs }}
+      binaries: ${{ steps.jobs-outputs.outputs.binaries }}
+      binary-list: ${{ steps.jobs-outputs.outputs.binary_list }}
+      logs: ${{ steps.jobs-outputs.outputs.logs }}
 
     container:
       image: ghcr.io/siemaapplications/zephyr-arm-build:v0.0.3
@@ -69,15 +74,15 @@ jobs:
           echo "repo_name=${repo_name}" >> $GITHUB_OUTPUT
           echo "manifest=${repo_name}/west.yml" >> $GITHUB_OUTPUT
 
-      - name: Get Artifacts Names
-        id: artifacts-names
+      - name: Compute Job Outputs
+        id: jobs-outputs
         run: |
           binaries="${{ inputs.twister-outdir }}-binaries"
           logs="${{ inputs.twister-outdir }}-build-logs"
-          echo "binaries=${binaries}"
-          echo "logs=${logs}"
-          echo "binaries=${binaries}" >> $GITHUB_OUTPUT
-          echo "logs=${logs}" >> $GITHUB_OUTPUT
+          binary_list="$(find . -name 'zephyr.bin' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+          echo "binaries=${binaries}" | tee -a $GITHUB_OUTPUT
+          echo "binary_list=${binary_list}" | tee -a $GITHUB_OUTPUT
+          echo "logs=${logs}" | tee -a $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -181,7 +186,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           retention-days: 7
-          name: ${{ steps.artifacts-names.outputs.logs }}
+          name: ${{ steps.jobs-outputs.outputs.logs }}
           path: |
             ${{ inputs.twister-outdir }}/**/build.log
 
@@ -189,7 +194,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           retention-days: 7
-          name: ${{ steps.artifacts-names.outputs.binaries }}
+          name: ${{ steps.jobs-outputs.outputs.binaries }}
           path: |
             ${{ inputs.twister-outdir }}/**/*.bin
             ${{ inputs.twister-outdir }}/**/*.elf


### PR DESCRIPTION
Artifacts from matrix job are hard to delete (no access to individual artifact names, and api can't access artifacts from the current workflow, we need to wait the end of the workflow).
So reduce retention to 1 day

Fixed workflow which use signing key