### PR TITLE
Add reusable workflow to build docker devenv

### DIFF
--- a/.github/workflows/build-docker-devenv.yml
+++ b/.github/workflows/build-docker-devenv.yml
@@ -1,0 +1,62 @@
+# Exemple of a caller workflow
+# on:
+#   push:
+#     branches: [ main ]
+#     tags:
+#       - 'devenv-v[0-9]+.[0-9]+.[0-9]+'
+# # Limit permissions of the GITHUB_TOKEN
+# permissions:
+#   contents: read  # needed to fetch source
+#   packages: write   # neeed to push image to ghcr.io
+# jobs:
+#   call-build-docker-devenv:
+#     uses: SiemaApplications/vossloh-gh-actions/.github/workflows/build-docker-devenv.yml@v7
+
+# Build docker image to use as devenv and store it on ghcr.io
+name: Devenv docker image
+
+on:
+  workflow_call:
+    secrets:
+      access-token:
+        description: 'Token with following permissions: "contents:read" needed to fetch source, and "packages:write" needed to push image to ghcr.io'
+        required: true
+
+
+jobs:
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the Repository
+      - name: Checking out the repository
+        uses: actions/checkout@v3
+
+      # Setting up Docker Builder
+      - name: Set up Docker Builder
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.access-token }}
+
+      # Extract tag name from git context
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}-devenv
+          # Just keep the version numbers from the git tag
+          # and trim the `devenv-v` part
+          tags: |
+            type=match,pattern=\d+.\d+.\d+
+
+      # Push to Github Container Registry
+      - name: Build and push to Github Container Registry
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+    python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
This allows to build and store a docker image on ghcr.io to make sure builds are done in a consistent environment

I have not tested this reusable workflow yet, but I have a functional very similar workflow: https://github.com/SiemaApplications/snt-tt-buildroot/blob/kernel510/.github/workflows/devenv-docker-image.yml