### PR TITLE
workflows: Bump actions/* to v4

### DIFF
--- a/.github/workflows/check_github_action_syntax.yml
+++ b/.github/workflows/check_github_action_syntax.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lint files
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Lint Files

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -87,7 +87,7 @@ jobs:
         run: sudo apt-get install -y srecord
 
       - name: Get MCUboot binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: ${{ needs.mcuboot_compil.outputs.binaries }}
@@ -125,7 +125,7 @@ jobs:
           find . -name "*.elf"
 
       - name: Upload MCUboot Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # We don't care of the binaries after the run
           retention-days: 1

--- a/.github/workflows/mcuboot-compilation-stm32h7.yml
+++ b/.github/workflows/mcuboot-compilation-stm32h7.yml
@@ -59,7 +59,7 @@ on:
 
 jobs:
   mcuboot_compil:
-    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v6
+    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v7
     with:
       app-dir: bootloader/mcuboot/boot/zephyr/
       board-root-dir: ${{ inputs.board-root-dir }}

--- a/.github/workflows/release-zephyr-app.yml
+++ b/.github/workflows/release-zephyr-app.yml
@@ -135,7 +135,7 @@ jobs:
       - release_infos
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: ${{needs.app_compilation.outputs.binaries}}

--- a/.github/workflows/release-zephyr-app.yml
+++ b/.github/workflows/release-zephyr-app.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Github Context
-        uses: SiemaApplications/vossloh-gh-actions/debug/show-github-context@v6
+        uses: SiemaApplications/vossloh-gh-actions/debug/show-github-context@v7
 
       # Inject build number into semver.
       - name: Release Infos
@@ -108,7 +108,7 @@ jobs:
           echo "release_name=${release_name}" | tee -a $GITHUB_ENV | tee -a $GITHUB_OUTPUT
 
   app_compilation:
-    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v6
+    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v7
     needs: release_infos
     with:
       app-dir: ${{ inputs.app-dir }}

--- a/.github/workflows/test_zephyr_workflows.yml
+++ b/.github/workflows/test_zephyr_workflows.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   signed_app:
     name: Zephyr Signed Application Compilation
-    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v6
+    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v7
     with:
       manifest: tests/zephyr/west.yml
       app-dir: zephyr/samples/subsys/usb/dfu/
@@ -28,7 +28,7 @@ jobs:
 
   unsigned_app:
     name: Zephyr Application Compilation
-    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v6
+    uses: SiemaApplications/vossloh-gh-actions/.github/workflows/twister-signed-compilation.yml@v7
     with:
       manifest: tests/zephyr/west.yml
       app-dir: zephyr/samples

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -101,12 +101,12 @@ jobs:
           echo "manifest=${repo_name}/${{inputs.manifest}}" |tee -a $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ steps.repo-info.outputs.repo_name }}
 
       - name: Cache West Module
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         env:
           cache-name: cache-west-modules
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload Build Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ steps.logs-artifact-name.outputs.logs }}
@@ -321,7 +321,7 @@ jobs:
             ${{ inputs.twister-outdir }}/**/build.log
 
       - name: Upload Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # We don't care of the binaries after the run
           retention-days: 1

--- a/.github/workflows/twister-signed-compilation.yml
+++ b/.github/workflows/twister-signed-compilation.yml
@@ -336,6 +336,6 @@ jobs:
             !${{ inputs.twister-outdir }}/**/isrList.bin
 
       - name: Check Twister Results
-        uses: SiemaApplications/vossloh-gh-actions/twister/results-analysis@v6
+        uses: SiemaApplications/vossloh-gh-actions/twister/results-analysis@v7
         with:
           twister-result-file: ${{ inputs.twister-outdir }}/twister.json


### PR DESCRIPTION
Avoid CI warnings about deprecated Node.js version.

The new version of these actions are based on Node.js-20.
* SiemaApplications/vossloh-gh-actions@v6 <=> actions/*@V3 <=> node.js-16
* SiemaApplications/vossloh-gh-actions@v7 <=> actions/*@v4 <=> node.js-20